### PR TITLE
feat(statCompactor.ts): only discard commits that are in the original repo's default branch

### DIFF
--- a/src/raids/statCompactor.ts
+++ b/src/raids/statCompactor.ts
@@ -128,7 +128,7 @@ export async function fetchAndFilterCommitData(
     /*
      * TODO: Find a better way to do this with the API, as it is subject to breaking at some point in the future
      */
-    const isRaidCommit = !new RegExp(dungeonRepoNameWithOwner).test(
+    const isRaidCommit = !new RegExp(`href="/${dungeonRepoNameWithOwner}"`).test(
       await got(
         `https://github.com/${dungeonRepoNameWithOwner}/branch_commits/${commitId}`
       ).text()


### PR DESCRIPTION
Research shared in OSRG's discord:

As far as I understand, the stat compactor is not counting commits that are in the original repository because of this check:

https://github.com/OpenSourceRaidGuild/Guild-Scrivener/blob/cb74190ce8d709b10447ad1f13baab70ef7af879/src/raids/statCompactor.ts#L131-L135

Based on that, many commits won't count in this raid because I pushed some branches to the original repo that contain commits from the raid.

For example, the commit `ed042e22cc8e94c86add196d9a55e95f51f0e2f8` is already in the original repo, and it won't count because the Regex test will find the string "HorusGoul/atom-pwa" in the response.

![image](https://user-images.githubusercontent.com/6759612/111357428-99912580-8689-11eb-9ba7-68351946f03c.png)

However, if I run the same request with a commit that is in the default branch of the original repo, 684d252c3e9502342bb30acbe23a7d075890f0d1 in this case, the result looks like this:

![image](https://user-images.githubusercontent.com/6759612/111357486-a6ae1480-8689-11eb-9a97-57a750312d7a.png)

As a fix, we could change the regex to check for href="/${dungeonRepoNameWithOwner}" and it should work unless there are more edge cases that I don't see right now.

What do you think?